### PR TITLE
Add link to cohoard and cohost to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cohoard - Post formatted chatlogs to Cohost!
 
-Cohoard is a tool for turning chatlogs into formatted posts on Cohost. You can use Cohoard to easily format your silly conversations like a Discord channel, an MSPA chatlog, and so on.
+[Cohoard](https://a2aaron.github.io/Cohoard/) is a tool for turning chatlogs into formatted posts on [Cohost](https://cohost.org/). You can use Cohoard to easily format your silly conversations like a Discord channel, an MSPA chatlog, and so on.
 
 ## Discord Template
 


### PR DESCRIPTION
# Problem

The README should link to the actual published Cohoard site, so that people who look at the repo can go and try it out!

# Solution

We add a link to Cohoard at the top of the README. We add a link to Cohost as well!