### PR TITLE
Try to make errors more useful to the JS side.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,6 +264,8 @@ fn markdown_to_html(
 }
 
 pub mod js {
+    use std::error::Error;
+
     use wasm_bindgen::prelude::*;
 
     #[wasm_bindgen]
@@ -279,6 +281,15 @@ pub mod js {
         Ok(PostBlockArray(JsValue::from_serde(&posts)?))
     }
 
+    fn get_full_msg(mut err: &dyn Error) -> String {
+        let mut messages = vec![err.to_string()];
+        while let Some(new_err) = err.source() {
+            err = new_err;
+            messages.push(err.to_string());
+        }
+        messages.join("\n")
+    }
+
     #[wasm_bindgen]
     pub fn render(
         template_name: &str,
@@ -286,13 +297,22 @@ pub mod js {
         posts: &PostBlockArray,
     ) -> Result<String, JsError> {
         let posts = posts.0.into_serde::<Vec<_>>()?;
-        super::render(template_name, template, &posts).map_err(|err| JsError::new(&err.to_string()))
+        super::render(template_name, template, &posts).map_err(|err| {
+            // Try to parse out a Tera error message, if one was encountered during rendering.
+            // TODO: provide more context?
+            if let Some(tera_error) = err.source().and_then(|e| e.downcast_ref::<tera::Error>()) {
+                if let tera::ErrorKind::Msg(msg) = &tera_error.kind {
+                    return JsError::new(msg);
+                }
+            }
+            JsError::new(&get_full_msg(err.as_ref()))
+        })
     }
 
     #[wasm_bindgen]
     pub fn load_config(config: &str) -> Result<Config, JsError> {
-        let config =
-            crate::config::load_config(config).map_err(|err| JsError::new(&err.to_string()))?;
+        let config = crate::config::load_config(config)
+            .map_err(|err| JsError::new(&get_full_msg(err.as_ref())))?;
         Ok(Config(JsValue::from_serde(&config)?))
     }
 }


### PR DESCRIPTION
Currently, errors just use `.to_string()` when sending them over to the JS side. This loses a lot of useful information however. We can improve this by recursively getting the inner `source` messages of the error and jamming them all into one big String.

Additionally, we can give better Tera errors by directly reporting then error's `msg` field. This should hopefully make it a bit easier to figure out why a render failed.

Must be merged with #28 

Would complete one task in #9 