### PR TITLE
adding heavier font weight to discord user names to more mimic discord appearance

### DIFF
--- a/templates/discord.html
+++ b/templates/discord.html
@@ -172,6 +172,7 @@ config-#}
    .{{user.key}}.headline-username {
       color: {{ user.color | default(value=username_default_color) }};
       font-size: 100%;
+      font-weight: 600;
    }
 
    .{{user.key}}.avatar {


### PR DESCRIPTION
i upped the font weight to 600 so that it looks bold like in discord

also i figured i could do it myself and open a pull request because it's CSS-y stuff, rather than ask you to do it

this is also my first pull request soooo i hope i did it right